### PR TITLE
PLATY-548: Include consuming service name in file metadata uploaded t…

### DIFF
--- a/app/filters/UserAgentFilter.scala
+++ b/app/filters/UserAgentFilter.scala
@@ -1,0 +1,22 @@
+package filters
+
+import play.api.Logger
+import play.api.http.HeaderNames
+import play.api.mvc.Action
+import play.api.mvc.Results.Forbidden
+
+import scala.concurrent.Future
+
+trait UserAgentFilter {
+
+  def withUserAgentHeader[A](action: Action[A]): Action[A] = Action.async(action.parser) { request =>
+    if (request.headers.get(HeaderNames.USER_AGENT).isDefined) {
+      action(request)
+    } else {
+      Logger.warn("Missing User-Agent header.")
+
+      Future.successful(Forbidden("This service is not allowed to use upscan-initiate. " +
+        "If you need to use this service, please contact Platform Services team."))
+    }
+  }
+}

--- a/app/services/PrepareUploadService.scala
+++ b/app/services/PrepareUploadService.scala
@@ -16,7 +16,7 @@ class PrepareUploadService @Inject()() {
     def asBase64String(): String = Json.stringify(json).base64encode
   }
 
-  def prepareUpload(settings: UploadSettings, uploadUrl: String): PreparedUpload = {
+  def prepareUpload(settings: UploadSettings, uploadUrl: String, consumingService: Option[String]): PreparedUpload = {
     val reference = generateReference()
     val policy = toPolicy(settings)
 
@@ -33,8 +33,8 @@ class PrepareUploadService @Inject()() {
           "x-amz-date"              -> dateTimeFormatter.format(Instant.now),
           "x-amz-meta-callback-url" -> settings.callbackUrl,
           "x-amz-signature"         -> "xxxx"
-        ) ++
-          settings.expectedContentType.map{"Content-Type" -> _}
+        ) ++ settings.expectedContentType.map{"Content-Type" -> _}
+          ++ consumingService.map{"x-amz-meta-consuming-service" -> _}
       )
     )
   }

--- a/it/services/NotificationSenderISpec.scala
+++ b/it/services/NotificationSenderISpec.scala
@@ -10,6 +10,7 @@ import model.PreparedUpload
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, GivenWhenThen}
+import play.api.http.HeaderNames.USER_AGENT
 import play.api.libs.Files.TemporaryFile
 import play.api.libs.json.Json
 import play.api.mvc.MultipartFormData
@@ -40,6 +41,8 @@ class NotificationSenderISpec
   implicit val materializer: ActorMaterializer = ActorMaterializer()
   implicit val timeout: akka.util.Timeout      = 10.seconds
 
+  val requestHeaders = FakeHeaders(Seq((USER_AGENT, "InitiateControllerISpec")))
+
   "UpscanStub" should {
     "initiate a request, upload a file, make a callback, and download a non-infected file" in {
 
@@ -58,7 +61,7 @@ class NotificationSenderISpec
         """.stripMargin)
 
       val initiateRequest =
-        FakeRequest(Helpers.POST, "/upscan/initiate", FakeHeaders(), postBodyJson)
+        FakeRequest(Helpers.POST, "/upscan/initiate", requestHeaders, postBodyJson)
 
       When("a request is posted to the /initiate endpoint")
       val initiateResponse = route(fakeApplication, initiateRequest).get
@@ -132,7 +135,7 @@ class NotificationSenderISpec
                                     """.stripMargin)
 
       val initiateRequest =
-        FakeRequest(Helpers.POST, "/upscan/initiate", FakeHeaders(), postBodyJson)
+        FakeRequest(Helpers.POST, "/upscan/initiate", requestHeaders, postBodyJson)
 
       When("a request is posted to the /initiate endpoint")
       val initiateResponse = route(fakeApplication, initiateRequest).get

--- a/test/controllers/InitiateControllerSpec.scala
+++ b/test/controllers/InitiateControllerSpec.scala
@@ -7,6 +7,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{GivenWhenThen, Matchers}
+import play.api.http.HeaderNames.USER_AGENT
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.Result
 import play.api.test.FakeRequest
@@ -22,6 +23,8 @@ class InitiateControllerSpec extends UnitSpec with Matchers with GivenWhenThen w
   implicit val materializer: ActorMaterializer = ActorMaterializer()
   implicit val timeout: akka.util.Timeout      = 10.seconds
 
+  val requestHeaders = ((USER_AGENT, "InitiateControllerSpec"))
+
   "UpscanController" should {
 
     "return expected JSON for prepare upload when passed valid request" in {
@@ -35,7 +38,7 @@ class InitiateControllerSpec extends UnitSpec with Matchers with GivenWhenThen w
           |}
         """.stripMargin)
 
-      val request = FakeRequest().withBody(validJsonBody)
+      val request = FakeRequest().withHeaders(requestHeaders).withBody(validJsonBody)
 
       When("the prepare upload method is called")
       val preparedUpload = PreparedUpload(
@@ -43,7 +46,7 @@ class InitiateControllerSpec extends UnitSpec with Matchers with GivenWhenThen w
         UploadFormTemplate("http://myservice.com/upload", Map.empty)
       )
       val prepareService = mock[PrepareUploadService]
-      Mockito.when(prepareService.prepareUpload(any(), any())).thenReturn(preparedUpload)
+      Mockito.when(prepareService.prepareUpload(any(), any(), any())).thenReturn(preparedUpload)
       val controller             = new InitiateController(prepareService)(ExecutionContext.Implicits.global)
       val result: Future[Result] = controller.prepareUpload()(request)
 
@@ -73,7 +76,7 @@ class InitiateControllerSpec extends UnitSpec with Matchers with GivenWhenThen w
           |}
         """.stripMargin)
 
-      val request = FakeRequest().withBody(invalidJsonBody)
+      val request = FakeRequest().withHeaders(requestHeaders).withBody(invalidJsonBody)
 
       When("the prepare upload method is called")
       val prepareService         = mock[PrepareUploadService]
@@ -88,7 +91,7 @@ class InitiateControllerSpec extends UnitSpec with Matchers with GivenWhenThen w
     "return expected error for prepare upload when passed non-JSON request" in {
       Given("a request containing an invalid JSON body")
       val invalidStringBody: String = "This is an invalid body"
-      val request                   = FakeRequest().withBody(invalidStringBody)
+      val request                   = FakeRequest().withHeaders(requestHeaders).withBody(invalidStringBody)
 
       When("the prepare upload method is called")
       val prepareService         = mock[PrepareUploadService]

--- a/test/services/PrepareUploadServiceSpec.scala
+++ b/test/services/PrepareUploadServiceSpec.scala
@@ -8,6 +8,7 @@ import uk.gov.hmrc.play.test.UnitSpec
 class PrepareUploadServiceSpec extends UnitSpec with Matchers {
   "PrepareUploadService.prepareUpload" should {
     val testInstance = new PrepareUploadService()
+    val userAgent = Some("PrepareUploadServiceSpec")
 
     val uploadSettings = UploadSettings(
       callbackUrl = "callbackUrl",
@@ -18,7 +19,7 @@ class PrepareUploadServiceSpec extends UnitSpec with Matchers {
 
     "include supplied file size constraints in the policy" in {
       val result: PreparedUpload =
-        testInstance.prepareUpload(uploadSettings.copy(minimumFileSize = Some(10), maximumFileSize = Some(100)), "uploadUrl")
+        testInstance.prepareUpload(uploadSettings.copy(minimumFileSize = Some(10), maximumFileSize = Some(100)), "uploadUrl", userAgent)
 
       withMinMaxFileSizesInPolicyConditions(result) { (min, max) =>
         min shouldBe Some(10)
@@ -28,7 +29,7 @@ class PrepareUploadServiceSpec extends UnitSpec with Matchers {
 
     "include default file size constraints in the policy" in {
       val result: PreparedUpload =
-        testInstance.prepareUpload(uploadSettings.copy(minimumFileSize = None, maximumFileSize = None), "uploadUrl")
+        testInstance.prepareUpload(uploadSettings.copy(minimumFileSize = None, maximumFileSize = None), "uploadUrl", userAgent)
 
       withMinMaxFileSizesInPolicyConditions(result) { (min, max) =>
         min shouldBe Some(0)
@@ -38,7 +39,7 @@ class PrepareUploadServiceSpec extends UnitSpec with Matchers {
 
     "include all required fields" in {
       val result: PreparedUpload =
-        testInstance.prepareUpload(uploadSettings, "uploadUrl")
+        testInstance.prepareUpload(uploadSettings, "uploadUrl", userAgent)
 
       result.uploadRequest.fields.keySet should contain theSameElementsAs Set(
         "acl",
@@ -48,6 +49,7 @@ class PrepareUploadServiceSpec extends UnitSpec with Matchers {
         "x-amz-credential",
         "x-amz-date",
         "x-amz-meta-callback-url",
+        "x-amz-meta-consuming-service",
         "x-amz-signature"
       )
     }


### PR DESCRIPTION
…o S3. Also added UserAgentFilter to check for non-empty header value.