### PR TITLE
PLATY-637 Storing every upload that uses the same initiate request as…

### DIFF
--- a/app/controllers/DownloadController.scala
+++ b/app/controllers/DownloadController.scala
@@ -1,9 +1,8 @@
 package controllers
 
-import javax.inject.Inject
-
 import akka.util.ByteString
-import model.Reference
+import javax.inject.Inject
+import model.FileId
 import play.api.http.HttpEntity
 import play.api.mvc.{Action, ResponseHeader, Result}
 import services.FileStorageService
@@ -11,9 +10,9 @@ import uk.gov.hmrc.play.bootstrap.controller.BaseController
 
 class DownloadController @Inject()(storageService: FileStorageService) extends BaseController {
 
-  def download(reference: String) = Action {
+  def download(fileId: String) = Action {
     (for {
-      source <- storageService.get(Reference(reference))
+      source <- storageService.get(FileId(fileId))
     } yield {
       Result(
         header = ResponseHeader(200, Map.empty),

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -103,9 +103,9 @@ class UploadController @Inject()(
     implicit request: RequestHeader): Unit = {
     val reference = Reference(form.key)
 
-    storageService.store(file.ref, reference)
+    val fileId = storageService.store(file.ref)
     val storedFile =
-      storageService.get(reference).getOrElse(throw new IllegalStateException("The file should have been stored"))
+      storageService.get(fileId).getOrElse(throw new IllegalStateException("The file should have been stored"))
 
     val foundVirus: ScanningResult = virusScanner.checkIfClean(storedFile)
 
@@ -119,7 +119,7 @@ class UploadController @Inject()(
         UploadedFile(
           callbackUrl   = new URL(form.callbackUrl),
           reference     = reference,
-          downloadUrl   = new URL(buildDownloadUrl(reference = reference)),
+          downloadUrl   = new URL(buildDownloadUrl(fileId = fileId)),
           uploadDetails = fileUploadDetails
         )
       }
@@ -143,8 +143,8 @@ class UploadController @Inject()(
       case _      => s"application/binary"
     }
 
-  private def buildDownloadUrl(reference: Reference)(implicit request: RequestHeader) =
-    routes.DownloadController.download(reference.value).absoluteURL()
+  private def buildDownloadUrl(fileId: FileId)(implicit request: RequestHeader) =
+    routes.DownloadController.download(fileId.value).absoluteURL()
 
   private def invalidRequestBody(code: String, message: String): Node =
     xml.XML.loadString(s"""<Error>

--- a/app/model/model.scala
+++ b/app/model/model.scala
@@ -2,12 +2,19 @@ package model
 
 import java.net.URL
 import java.time.Instant
+import java.util.UUID
 
 import play.api.libs.json._
 
 //Common
 
 case class Reference(value: String)
+
+case class FileId(value: String)
+
+object FileId {
+  def generate() = FileId(UUID.randomUUID().toString)
+}
 
 object Reference {
   implicit val referenceFormat: Format[Reference] = new Format[Reference] {

--- a/app/services/FileStorageService.scala
+++ b/app/services/FileStorageService.scala
@@ -4,7 +4,7 @@ import java.io.File
 import java.nio.file.Files
 
 import javax.inject.Singleton
-import model.Reference
+import model.FileId
 import org.apache.commons.io.FileUtils
 import play.api.libs.{Files => PlayFiles}
 
@@ -15,12 +15,15 @@ class FileStorageService {
 
   private val tempDirectory: File = Files.createTempDirectory("upscan").toFile
 
-  def store(temporaryFile: PlayFiles.TemporaryFile, reference: Reference): Unit =
-    temporaryFile.moveTo(buildFileLocation(reference))
+  def store(temporaryFile: PlayFiles.TemporaryFile): FileId = {
+    val fileId = FileId.generate()
+    temporaryFile.moveTo(buildFileLocation(fileId))
+    fileId
+  }
 
-  def get(reference: Reference): Option[StoredFile] =
-    for { file <- Some(buildFileLocation(reference)) if file.exists() && file.isFile && file.canRead } yield
+  def get(fileId: FileId): Option[StoredFile] =
+    for { file <- Some(buildFileLocation(fileId)) if file.exists() && file.isFile && file.canRead } yield
       StoredFile(FileUtils.readFileToByteArray(file))
 
-  private def buildFileLocation(reference: Reference) = new File(tempDirectory, reference.value)
+  private def buildFileLocation(reference: FileId) = new File(tempDirectory, reference.value)
 }

--- a/it/controllers/DownloadControllerISpec.scala
+++ b/it/controllers/DownloadControllerISpec.scala
@@ -5,7 +5,7 @@ import java.nio.file.{Files, Paths}
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import model.Reference
+import model.{FileId, Reference}
 import org.scalatest.GivenWhenThen
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.Files.TemporaryFile
@@ -31,9 +31,9 @@ class DownloadControllerISpec extends UnitSpec with GuiceOneAppPerSuite with Giv
       Files.write(file.toPath, "Integration test file contents".getBytes)
 
       val storageService = app.injector.instanceOf[FileStorageService]
-      storageService.store(new TemporaryFile(file), Reference("my-it-file"))
+      val fileId         = storageService.store(new TemporaryFile(file))
 
-      val downloadRequest = FakeRequest(Helpers.GET, "/upscan/download/my-it-file")
+      val downloadRequest = FakeRequest(Helpers.GET, s"/upscan/download/${fileId.value}")
 
       When("a GET request is made to /download/:reference endpoint")
       val downloadResponse = route(app, downloadRequest).get

--- a/it/services/NotificationSenderISpec.scala
+++ b/it/services/NotificationSenderISpec.scala
@@ -105,20 +105,20 @@ class NotificationSenderISpec
       eventually {
         val expectedCallback = Json
           .obj(
-            "reference"   -> fileReference,
-            "downloadUrl" -> s"http:/upscan/download/$fileReference",
-            "fileStatus"  -> "READY",
+            "reference"  -> fileReference,
+            "fileStatus" -> "READY",
             "uploadDetails" -> Json.obj(
               "uploadTimestamp" -> "2018-04-24T09:30:00Z",
               "checksum"        -> "2f8a8ceeec0dc64ffaca269f55e74699bee881749de20cdb9631f8fcc72f8a62",
               "fileMimeType"    -> "application/pdf",
               "fileName"        -> "my-it-file.pdf"
+              //Excluding downloadUrl
             )
           )
           .toString
         verify(
           1,
-          postRequestedFor(urlEqualTo("/upscan/callback")).withRequestBody(containing(expectedCallback.toString)))
+          postRequestedFor(urlEqualTo("/upscan/callback")).withRequestBody(equalToJson(expectedCallback, true, true)))
 
         Then("the expected file should be available for download from the URL in the callback body")
         val callbackBody = getAllServeEvents.toList.head.getRequest.getBodyAsString

--- a/test/controllers/DownloadControllerSpec.scala
+++ b/test/controllers/DownloadControllerSpec.scala
@@ -2,7 +2,7 @@ package controllers
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import model.Reference
+import model.{FileId, Reference}
 import org.mockito.Mockito
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{GivenWhenThen, Matchers}
@@ -23,16 +23,16 @@ class DownloadControllerSpec extends UnitSpec with Matchers with GivenWhenThen w
   "DownloadController" should {
     "retrieve file from storage if available" in {
       Given("a valid file reference")
-      val validReference = "123-efg-789-0"
-      val storedFile     = Some(StoredFile("Here is some file contents".getBytes))
+      val validFileId = "123-efg-789-0"
+      val storedFile  = Some(StoredFile("Here is some file contents".getBytes))
 
       val storageService = mock[FileStorageService]
-      Mockito.when(storageService.get(Reference(validReference))).thenReturn(storedFile)
+      Mockito.when(storageService.get(FileId(validFileId))).thenReturn(storedFile)
 
       val controller = new DownloadController(storageService)
 
       When("download is called")
-      val downloadResult: Future[Result] = controller.download(validReference)(FakeRequest())
+      val downloadResult: Future[Result] = controller.download(validFileId)(FakeRequest())
 
       Then("a successful response should be returned")
       val downloadStatus = status(downloadResult)
@@ -45,16 +45,16 @@ class DownloadControllerSpec extends UnitSpec with Matchers with GivenWhenThen w
 
     "return Not Found if file not available" in {
       Given("an valid file reference")
-      val validReference = "123-efg-789-0"
-      val storedFile     = None
+      val validFileId = "123-efg-789-0"
+      val storedFile  = None
 
       val storageService = mock[FileStorageService]
-      Mockito.when(storageService.get(Reference(validReference))).thenReturn(storedFile)
+      Mockito.when(storageService.get(FileId(validFileId))).thenReturn(storedFile)
 
       val controller = new DownloadController(storageService)
 
       When("download is called")
-      val downloadResult: Future[Result] = controller.download(validReference)(FakeRequest())
+      val downloadResult: Future[Result] = controller.download(validFileId)(FakeRequest())
 
       Then("a Not Found response should be returned")
       val downloadStatus = status(downloadResult)

--- a/test/services/FileStorageServiceSpec.scala
+++ b/test/services/FileStorageServiceSpec.scala
@@ -3,7 +3,7 @@ package services
 import java.nio.file.Files
 import java.util.UUID
 
-import model.Reference
+import model.{FileId, Reference}
 import org.apache.commons.io.FileUtils
 import org.scalatest.{GivenWhenThen, Matchers}
 import play.api.libs.Files.TemporaryFile
@@ -25,17 +25,17 @@ class FileStorageServiceSpec extends UnitSpec with Matchers with GivenWhenThen {
       FileUtils.writeByteArrayToFile(temporaryFile.file, fileBody)
 
       When("we store content of temporary file to the service")
-      fileStorageService.store(temporaryFile, reference)
+      val fileId = fileStorageService.store(temporaryFile)
 
       Then("we should be able to read this content")
-      val retrievedFile = fileStorageService.get(reference)
+      val retrievedFile = fileStorageService.get(fileId)
       retrievedFile          shouldBe defined
       retrievedFile.get.body shouldBe fileBody
 
     }
 
     "Return empty result when trying to retrieve non-existent file" in {
-      val retrievedFile = fileStorageService.get(Reference("non-existent-file"))
+      val retrievedFile = fileStorageService.get(FileId("non-existent-file"))
       retrievedFile shouldBe empty
     }
 


### PR DESCRIPTION
… a separate file, to guarantee consistency when downloading.