### PR TITLE
Add support of `success_action_redirect` form S3 behaviour.

### DIFF
--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -36,7 +36,8 @@ class UploadController @Inject()(
       "x-amz-signature"         -> nonEmptyText,
       "acl"                     -> nonEmptyText.verifying("Invalid acl", { "private" == _ }),
       "key"                     -> nonEmptyText,
-      "x-amz-meta-callback-url" -> nonEmptyText
+      "x-amz-meta-callback-url" -> nonEmptyText,
+      "success_action_redirect" -> optional(text)
     )(UploadPostForm.apply)(UploadPostForm.unapply)
   )
 
@@ -66,7 +67,9 @@ class UploadController @Inject()(
       validInput =>
         withPolicyChecked(validInput._1, validInput._2) {
           storeAndNotify(validInput._1, validInput._2)
-          NoContent
+          validInput._1.successActionRedirect.fold(NoContent){ url =>
+            Redirect(url)
+          }
       }
     )
   }

--- a/app/model/model.scala
+++ b/app/model/model.scala
@@ -64,7 +64,8 @@ case class UploadPostForm(
   signature: String,
   acl: String,
   key: String,
-  callbackUrl: String
+  callbackUrl: String,
+  successActionRedirect: Option[String]
 )
 
 //Internal model of uploaded file


### PR DESCRIPTION
For pure HTML solution support for this form filed is very useful to continue interaction with user.
Without it we don't have method to perform any action when upload is finished.

Ref: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html